### PR TITLE
Store Vlq data inline

### DIFF
--- a/benches/basic.rs
+++ b/benches/basic.rs
@@ -1,0 +1,32 @@
+#![feature(test)]
+
+extern crate test;
+use test::Bencher;
+
+use std::convert::TryFrom;
+use vlq_rust::Vlq;
+
+#[bench]
+fn test_u8(b: &mut Bencher) {
+    b.iter(|| u8::try_from(Vlq::from(std::u8::MAX)));
+}
+
+#[bench]
+fn test_u16(b: &mut Bencher) {
+    b.iter(|| u16::try_from(Vlq::from(std::u16::MAX)));
+}
+
+#[bench]
+fn test_u32(b: &mut Bencher) {
+    b.iter(|| u32::try_from(Vlq::from(std::u32::MAX)));
+}
+
+#[bench]
+fn test_u64(b: &mut Bencher) {
+    b.iter(|| u64::try_from(Vlq::from(std::u64::MAX)));
+}
+
+#[bench]
+fn test_u128(b: &mut Bencher) {
+    b.iter(|| u128::try_from(Vlq::from(std::u128::MAX)));
+}


### PR DESCRIPTION
Should use up the same amount of inline space as a `Vec<u8>`, but stores the representation immediately.

This avoids accessing the heap-allocated data with the only downside being that we'll either have to expand or provide different representations it in case we support wider types.

Also provides a `bin` function to support debugging, all though I'll happily drop this if you find it useless.

Benches before:

```
running 5 tests
test test_u128 ... bench:         133 ns/iter (+/- 0)
test test_u16  ... bench:         104 ns/iter (+/- 0)
test test_u32  ... bench:         107 ns/iter (+/- 1)
test test_u64  ... bench:         113 ns/iter (+/- 1)
test test_u8   ... bench:         102 ns/iter (+/- 1)
```

Benches after:

```
running 5 tests
test test_u128 ... bench:          27 ns/iter (+/- 0)
test test_u16  ... bench:           7 ns/iter (+/- 0)
test test_u32  ... bench:           9 ns/iter (+/- 0)
test test_u64  ... bench:          13 ns/iter (+/- 0)
test test_u8   ... bench:           6 ns/iter (+/- 0)
```